### PR TITLE
365 set ahead and behind properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,8 @@ Now you just have to include such a properties file in your project under `/src/
 ```
 git.tags=${git.tags}
 git.branch=${git.branch}
+git.branch.ahead=${git.branch.ahead}
+git.branch.behind=${git.branch.behind}
 git.dirty=${git.dirty}
 git.remote.origin.url=${git.remote.origin.url}
   git.commit.id=${git.commit.id}

--- a/README.md
+++ b/README.md
@@ -565,8 +565,8 @@ Now you just have to include such a properties file in your project under `/src/
 ```
 git.tags=${git.tags}
 git.branch=${git.branch}
-git.branch.ahead=${git.branch.ahead}
-git.branch.behind=${git.branch.behind}
+git.local.branch.ahead=${git.local.branch.ahead}
+git.local.branch.behind=${git.local.branch.behind}
 git.dirty=${git.dirty}
 git.remote.origin.url=${git.remote.origin.url}
   git.commit.id=${git.commit.id}

--- a/src/main/java/pl/project13/maven/git/AheadBehind.java
+++ b/src/main/java/pl/project13/maven/git/AheadBehind.java
@@ -1,0 +1,60 @@
+package pl.project13.maven.git;
+
+import java.util.Objects;
+
+public class AheadBehind {
+
+  public static final AheadBehind NO_REMOTE = AheadBehind.of("NO_REMOTE", "NO_REMOTE");
+
+  private final String ahead;
+
+  private final String behind;
+
+  private AheadBehind(String ahead, String behind) {
+    this.ahead = ahead;
+    this.behind = behind;
+  }
+
+  public static AheadBehind of(int ahead, int behind) {
+    return new AheadBehind(String.valueOf(ahead), String.valueOf(behind));
+  }
+
+  public static AheadBehind of(String ahead, String behind) {
+    return new AheadBehind(ahead, behind);
+  }
+
+  public String ahead() {
+    return ahead;
+  }
+
+  public String behind() {
+    return behind;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ahead, behind);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    AheadBehind other = (AheadBehind) obj;
+
+    if (!Objects.equals(ahead, other.ahead)) {
+      return false;
+    }
+    if (!Objects.equals(behind, other.behind)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
@@ -3,8 +3,8 @@ package pl.project13.maven.git;
 public class GitCommitPropertyConstant {
   // these properties will be exposed to maven
   public static final String BRANCH = "branch";
-  public static final String BRANCH_AHEAD = "branch.ahead";
-  public static final String BRANCH_BEHIND = "branch.behind";
+  public static final String LOCAL_BRANCH_AHEAD = "local.branch.ahead";
+  public static final String LOCAL_BRANCH_BEHIND = "local.branch.behind";
   public static final String DIRTY = "dirty";
   // only one of the following two will be exposed, depending on the commitIdGenerationMode
   public static final String COMMIT_ID_FLAT = "commit.id";

--- a/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
@@ -3,6 +3,8 @@ package pl.project13.maven.git;
 public class GitCommitPropertyConstant {
   // these properties will be exposed to maven
   public static final String BRANCH = "branch";
+  public static final String BRANCH_AHEAD = "branch.ahead";
+  public static final String BRANCH_BEHIND = "branch.behind";
   public static final String DIRTY = "dirty";
   // only one of the following two will be exposed, depending on the commitIdGenerationMode
   public static final String COMMIT_ID_FLAT = "commit.id";

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -149,6 +149,13 @@ public abstract class GitDataProvider implements GitProvider {
       put(properties,GitCommitPropertyConstant.CLOSEST_TAG_COMMIT_COUNT, getClosestTagCommitCount());
 
       put(properties,GitCommitPropertyConstant.TOTAL_COMMIT_COUNT, getTotalCommitCount());
+      try {
+        AheadBehind aheadBehind = getAheadBehind();
+        put(properties, GitCommitPropertyConstant.BRANCH_AHEAD, aheadBehind.ahead());
+        put(properties, GitCommitPropertyConstant.BRANCH_BEHIND, aheadBehind.behind());  
+      } catch (Exception e) {
+        log.error("Failed to read ahead behind", e);
+      }
     } finally {
       finalCleanUp();
     }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -151,8 +151,8 @@ public abstract class GitDataProvider implements GitProvider {
       put(properties,GitCommitPropertyConstant.TOTAL_COMMIT_COUNT, getTotalCommitCount());
       try {
         AheadBehind aheadBehind = getAheadBehind();
-        put(properties, GitCommitPropertyConstant.BRANCH_AHEAD, aheadBehind.ahead());
-        put(properties, GitCommitPropertyConstant.BRANCH_BEHIND, aheadBehind.behind());  
+        put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_AHEAD, aheadBehind.ahead());
+        put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_BEHIND, aheadBehind.behind());  
       } catch (Exception e) {
         log.error("Failed to read ahead behind", e);
       }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -149,13 +149,10 @@ public abstract class GitDataProvider implements GitProvider {
       put(properties,GitCommitPropertyConstant.CLOSEST_TAG_COMMIT_COUNT, getClosestTagCommitCount());
 
       put(properties,GitCommitPropertyConstant.TOTAL_COMMIT_COUNT, getTotalCommitCount());
-      try {
-        AheadBehind aheadBehind = getAheadBehind();
-        put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_AHEAD, aheadBehind.ahead());
-        put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_BEHIND, aheadBehind.behind());  
-      } catch (Exception e) {
-        log.error("Failed to read ahead behind", e);
-      }
+      
+      AheadBehind aheadBehind = getAheadBehind();
+      put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_AHEAD, aheadBehind.ahead());
+      put(properties, GitCommitPropertyConstant.LOCAL_BRANCH_BEHIND, aheadBehind.behind());  
     } finally {
       finalCleanUp();
     }

--- a/src/main/java/pl/project13/maven/git/GitProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitProvider.java
@@ -40,5 +40,7 @@ public interface GitProvider {
   String getTotalCommitCount() throws GitCommitIdExecutionException;
 
   void finalCleanUp() throws GitCommitIdExecutionException;
+  
+  AheadBehind getAheadBehind() throws GitCommitIdExecutionException;
 
 }

--- a/src/test/java/pl/project13/maven/git/AheadBehindTest.java
+++ b/src/test/java/pl/project13/maven/git/AheadBehindTest.java
@@ -1,0 +1,137 @@
+package pl.project13.maven.git;
+
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public abstract class AheadBehindTest<T extends GitProvider> {
+
+    @Rule
+    public TemporaryFolder remoteRepository = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder localRepository = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder secondLocalRepository = new TemporaryFolder();
+
+    protected Git localRepositoryGit;
+
+    protected Git secondLocalRepositoryGit;
+
+    protected T gitProvider;
+
+    @Before
+    public void setup() throws Exception {
+
+	createRemoteRepository();
+
+	setupLocalRepository();
+
+	createAndPushInitialCommit();
+
+	setupSecondLocalRepository();
+
+	gitProvider = gitProvider();
+
+	extraSetup();
+    }
+
+    protected abstract T gitProvider();
+
+    protected void extraSetup() {
+	// Override in subclass to perform extra stuff in setup
+    }
+
+    @Test
+    public void shouldNotBeAheadOrBehind() throws Exception {
+
+	AheadBehind aheadBehind = gitProvider.getAheadBehind();
+	assertThat(aheadBehind.ahead(), CoreMatchers.is("0"));
+	assertThat(aheadBehind.behind(), CoreMatchers.is("0"));
+    }
+
+    @Test
+    public void shouldBe1Ahead() throws Exception {
+
+	createLocalCommit();
+
+	AheadBehind aheadBehind = gitProvider.getAheadBehind();
+	assertThat(aheadBehind.ahead(), CoreMatchers.is("1"));
+	assertThat(aheadBehind.behind(), CoreMatchers.is("0"));
+    }
+
+    @Test
+    public void shouldBe1Behind() throws Exception {
+
+	createCommitInSecondRepoAndPush();
+
+	AheadBehind aheadBehind = gitProvider.getAheadBehind();
+	assertThat(aheadBehind.ahead(), CoreMatchers.is("0"));
+	assertThat(aheadBehind.behind(), CoreMatchers.is("1"));
+    }
+
+    @Test
+    public void shouldBe1AheadAnd1Behind() throws Exception {
+
+	createLocalCommit();
+	createCommitInSecondRepoAndPush();
+
+	AheadBehind aheadBehind = gitProvider.getAheadBehind();
+	assertThat(aheadBehind.ahead(), CoreMatchers.is("1"));
+	assertThat(aheadBehind.behind(), CoreMatchers.is("1"));
+    }
+
+    protected void createLocalCommit() throws Exception {
+	File newFile = localRepository.newFile();
+	localRepositoryGit.add().addFilepattern(newFile.getName()).call();
+	localRepositoryGit.commit().setMessage("ahead").call();
+    }
+
+    protected void createCommitInSecondRepoAndPush() throws Exception {
+	secondLocalRepositoryGit.pull().call();
+
+	File newFile = secondLocalRepository.newFile();
+	secondLocalRepositoryGit.add().addFilepattern(newFile.getName()).call();
+	secondLocalRepositoryGit.commit().setMessage("behind").call();
+
+	secondLocalRepositoryGit.push().call();
+    }
+
+    protected void createRemoteRepository() throws Exception {
+	Git.init().setBare(true).setDirectory(remoteRepository.getRoot()).call();
+    }
+
+    protected void setupLocalRepository() throws Exception {
+	localRepositoryGit = Git.cloneRepository().setURI(remoteRepository.getRoot().toURI().toString())
+		.setDirectory(localRepository.getRoot()).setBranch("master").call();
+
+	StoredConfig config = localRepositoryGit.getRepository().getConfig();
+	config.setString(ConfigConstants.CONFIG_BRANCH_SECTION, "master", "remote", "origin");
+	config.setString(ConfigConstants.CONFIG_BRANCH_SECTION, "master", "merge", "refs/heads/master");
+	config.save();
+    }
+
+    protected void setupSecondLocalRepository() throws Exception {
+	secondLocalRepositoryGit = Git.cloneRepository().setURI(remoteRepository.getRoot().toURI().toString())
+		.setDirectory(secondLocalRepository.getRoot()).setBranch("master").call();
+    }
+
+    protected void createAndPushInitialCommit() throws Exception {
+	File newFile = localRepository.newFile();
+	localRepositoryGit.add().addFilepattern(newFile.getName()).call();
+	localRepositoryGit.commit().setMessage("initial").call();
+
+	localRepositoryGit.push().call();
+    }
+
+}

--- a/src/test/java/pl/project13/maven/git/JgitProviderAheadBehindTest.java
+++ b/src/test/java/pl/project13/maven/git/JgitProviderAheadBehindTest.java
@@ -1,0 +1,16 @@
+package pl.project13.maven.git;
+
+import java.nio.file.Paths;
+
+public class JgitProviderAheadBehindTest extends AheadBehindTest<JGitProvider> {
+
+    @Override
+    public void extraSetup() {
+	gitProvider.setRepository(localRepositoryGit.getRepository());
+    }
+
+    @Override
+    protected JGitProvider gitProvider() {
+	return new JGitProvider(Paths.get(localRepository.getRoot().getAbsolutePath(), ".git").toFile(), null);
+    }
+}

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -44,7 +44,9 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest {
     "git.commit.message.short",
     "git.commit.time",
     "git.total.commit.count",
-    "git.remote.origin.url"
+    "git.remote.origin.url",
+    "git.branch.ahead",
+    "git.branch.behind"
   };
 
   public static final String DEFAULT_FORMAT_STRING  = "yyyy-MM-dd'T'HH:mm:ssZ";
@@ -87,7 +89,7 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest {
   }
 
   @Test
-  public void testCompareISO8601Time() throws Exception {
+  public void testCompareIso8601Time() throws Exception {
     // Test on all available basic repos to ensure that the output is identical.
     for (AvailableGitTestRepo testRepo : AvailableGitTestRepo.values()) {
       if (testRepo != AvailableGitTestRepo.GIT_COMMIT_ID) {

--- a/src/test/java/pl/project13/maven/git/NativeProviderAheadBehindTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeProviderAheadBehindTest.java
@@ -1,0 +1,9 @@
+package pl.project13.maven.git;
+
+public class NativeProviderAheadBehindTest extends AheadBehindTest<NativeGitProvider> {
+
+    @Override
+    protected NativeGitProvider gitProvider() {
+	return new NativeGitProvider(localRepository.getRoot(), 1000l, null);
+    }
+}

--- a/src/test/java/pl/project13/maven/git/NativeProviderAheadBehindTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeProviderAheadBehindTest.java
@@ -6,4 +6,9 @@ public class NativeProviderAheadBehindTest extends AheadBehindTest<NativeGitProv
     protected NativeGitProvider gitProvider() {
 	return new NativeGitProvider(localRepository.getRoot(), 1000l, null);
     }
+    
+    @Override
+    protected void extraSetup() {
+	gitProvider.setEvaluateOnCommit("HEAD");
+    }
 }


### PR DESCRIPTION
### Context
Added git.branch.ahead and git.branch.behind, which could be used to verify synced with remote.

https://github.com/ktoso/maven-git-commit-id-plugin/issues/365

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
Since remote repository is required, no. Have done a bunch of manual local tests.
- [X] Update the Readme or any other documentation (including relevant Javadoc)
Just added the properties
- [X] Ensured that tests pass locally: `mvn clean package`
Verified tests in Eclipse, not able to run mvn clean package, surefire complains about some class missing. Guess it's a jdk-issue for me.
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
