### PR TITLE
#336 / #396: apply some refactoring to simplify the entire process launching

### DIFF
--- a/src/test/java/pl/project13/maven/git/BigDiffTest.java
+++ b/src/test/java/pl/project13/maven/git/BigDiffTest.java
@@ -33,9 +33,9 @@ import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Run this to simulate hanging native-git-process for repo-state with lots of changes.
- * 
+ *
  * The test case will still finish successfully because all git-related errors are cught in.
- * 
+ *
  * @author eternach
  *
  */


### PR DESCRIPTION
This is a follow up of #336 / #396 that deploys some simplifications and refactoring around the process launching.

### Contributor Checklist
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
