### PR TITLE
#389 allow replacementProperty value to be empty

### DIFF
--- a/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
+++ b/src/main/java/pl/project13/maven/git/PropertiesReplacer.java
@@ -95,19 +95,19 @@ public class PropertiesReplacer {
   }
 
   private String replaceRegex(String content, String token, String value) {
-    if ((token == null) || (value == null)) {
-      log.error("found replacementProperty without required token or value.");
+    if (token == null) {
+      log.error("found replacementProperty without required token.");
       return content;
     }
     final Pattern compiledPattern = Pattern.compile(token);
-    return compiledPattern.matcher(content).replaceAll(value);
+    return compiledPattern.matcher(content).replaceAll(value == null ? "" : value);
   }
 
   private String replaceNonRegex(String content, String token, String value) {
-    if ((token == null) || (value == null)) {
-      log.error("found replacementProperty without required token or value.");
+    if (token == null) {
+      log.error("found replacementProperty without required token.");
       return content;
     }
-    return content.replace(token, value);
+    return content.replace(token, value == null ? "" : value);
   }
 }

--- a/src/main/java/pl/project13/maven/git/ReplacementProperty.java
+++ b/src/main/java/pl/project13/maven/git/ReplacementProperty.java
@@ -59,8 +59,8 @@ public class ReplacementProperty {
    * The text to be written over any found tokens. 
    * You can also reference grouped regex matches made in the token here by $1, $2, etc.
    */
-  @Parameter(required = true)
-  private String value;
+  @Parameter(defaultValue = "")
+  private String value = "";
 
   /**
    * Indicates if the token should be located with regular expressions. 

--- a/src/test/java/pl/project13/maven/git/PropertiesReplacerTest.java
+++ b/src/test/java/pl/project13/maven/git/PropertiesReplacerTest.java
@@ -66,6 +66,20 @@ public class PropertiesReplacerTest {
     Properties exptecedProperties = build("key1", "another1", "key2", "value2");
     assertEquals(exptecedProperties, actualProperties);
   }
+  
+  @Test
+  @Parameters(method = "useRegexReplacement")
+  public void testPerformReplacementWithSinglePropertyEmptyValue(boolean regex) throws IOException {
+    Properties actualProperties = build("key1", "value1", "key2", "value2");
+
+    List<ReplacementProperty> replacementProperties = new ArrayList<>();
+    replacementProperties.add(new ReplacementProperty("key1", null, "value", null, regex, null));
+
+    propertiesReplacer.performReplacement(actualProperties, replacementProperties);
+
+    Properties exptecedProperties = build("key1", "1", "key2", "value2");
+    assertEquals(exptecedProperties, actualProperties);
+  }
 
   @Test
   @Parameters(method = "useRegexReplacement")
@@ -78,6 +92,20 @@ public class PropertiesReplacerTest {
     propertiesReplacer.performReplacement(actualProperties, replacementProperties);
 
     Properties exptecedProperties = build("key1", "another1", "key2", "another2");
+    assertEquals(exptecedProperties, actualProperties);
+  }
+  
+  @Test
+  @Parameters(method = "useRegexReplacement")
+  public void testPerformReplacementWithMultiplePropertiesEmptyValue(boolean regex) throws IOException {
+    Properties actualProperties = build("key1", "value1", "key2", "value2");
+
+    List<ReplacementProperty> replacementProperties = new ArrayList<>();
+    replacementProperties.add(new ReplacementProperty(null, null, "value", null, regex, null));
+
+    propertiesReplacer.performReplacement(actualProperties, replacementProperties);
+
+    Properties exptecedProperties = build("key1", "1", "key2", "2");
     assertEquals(exptecedProperties, actualProperties);
   }
 


### PR DESCRIPTION
### Context
Allow for value to be empty in replacement property.

https://github.com/git-commit-id/maven-git-commit-id-plugin/issues/389

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
