### PR TITLE
update com.fasterxml.jackson.core for CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
 
     <!-- Joda Time -->

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.1</version>
+      <version>2.10.2</version>
     </dependency>
 
     <!-- Guava -->


### PR DESCRIPTION
update com.fasterxml.jackson.core:jackson-databind 2.9.8 -> 2.9.9 as per [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086)
> A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. 

Based on this, this project does not seem to be affected in any way by this, but we still should update.