### PR TITLE
Correct text bold formatting on license text

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Getting the plugin
 The plugin **is available from Maven Central** (<a href="http://search.maven.org/#search%7Cga%7C1%7Cpl.project13">see here</a>), so you don't have to configure any additional repositories to use this plugin.
 
 A detailed description of using the plugin is available in the [Using the plugin](docs/using-the-plugin.md) section. All you need to do in the basic setup is to include that plugin definition in your `pom.xml`.
-For more advanced users we also prepared a [guide to provide a brief overview of the moreadvanced configurations](docs/using-the-plugin.md)<a>... read on!
+For more advanced users we also prepared a [guide to provide a brief overview of the more advanced configurations](docs/using-the-plugin.md)<a>... read on!
 
 Versions
 --------
@@ -110,6 +110,7 @@ Notable happy users
 License
 =======
 <img style="float:right; padding:3px; " src="https://github.com/git-commit-id/maven-git-commit-id-plugin/raw/master/lgplv3-147x51.png" alt="GNU LGPL v3"/>
+
 I'm releasing this plugin under the **GNU Lesser General Public License 3.0**.
 
 You're free to use it as you wish, the full license text is attached in the LICENSE file.


### PR DESCRIPTION
The bold text formatting is not working as there are is no whitespace
line between the `<img>` tag  and the line of text describing the
license under which this plugins is being released.

This commit adds a line of whitespace so that the bold text is
formatted correctly, and it also fixes a typo in one of the hyperlinks.

### Context
I tried out your plugin today in my project and it is giving me something that I have been looking to use for a long time.

To show my gratitude, I have fixed a few problems in the main README.md file.  I will spend some more time reading over the rest of the documentation to get to know how to use your awesome plugin in more advanced situations.

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`