### PR TITLE
Introduce "offline" mode

### DIFF
--- a/docs/using-the-plugin.md
+++ b/docs/using-the-plugin.md
@@ -234,6 +234,18 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     -->
                     <skip>false</skip>
 
+                    <!-- @since 3.0.1 -->
+                    <--
+                        Default (optional):
+                        false
+
+                        Explanation:
+                        When set to `true`, the plugin will not try to contact any remote repositories.
+                        Any operations will only use the local state of the repo. If set to `false`, it will execute `git fetch` operations
+                        e.g. to determine the `ahead` and `behind` branch information.
+                    -->
+                    <offline>false</offline>
+
                     <!-- @since 2.1.12 -->
                     <!--
                         Default (optional):

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import pl.project13.maven.git.build.BuildServerDataProvider;
@@ -69,6 +70,12 @@ public class GitCommitIdMojo extends AbstractMojo {
    */
   @Parameter(property = "session", required = true, readonly = true)
   MavenSession session;
+
+  /**
+   * The Maven settings.
+   */
+  @Parameter(property = "settings", required = true, readonly = true)
+  Settings settings;
 
   /**
    * <p>Set this to {@code 'true'} to inject git properties into all reactor projects, not just the current one.</p>
@@ -572,7 +579,7 @@ public class GitCommitIdMojo extends AbstractMojo {
               .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment)
               .setExcludeProperties(excludeProperties)
               .setIncludeOnlyProperties(includeOnlyProperties)
-              .setOffline(offline);
+              .setOffline(offline || settings.isOffline());
 
       nativeGitProvider.loadGitData(evaluateOnCommit, properties);
     } catch (IOException e) {
@@ -592,7 +599,7 @@ public class GitCommitIdMojo extends AbstractMojo {
         .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment)
         .setExcludeProperties(excludeProperties)
         .setIncludeOnlyProperties(includeOnlyProperties)
-        .setOffline(offline);
+        .setOffline(offline || settings.isOffline());
 
     jGitProvider.loadGitData(evaluateOnCommit, properties);
   }

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -331,7 +331,15 @@ public class GitCommitIdMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = "true")
   boolean injectIntoSysProperties;
-  
+
+  /**
+   * Controls whether the git plugin tries to access remote repos to fetch latest information
+   * or only use local information.
+   * @since 3.0.1
+   */
+  @Parameter(defaultValue = "false")
+  boolean offline;
+
   /**
    * Injected {@link BuildContext} to recognize incremental builds.
    */
@@ -563,7 +571,8 @@ public class GitCommitIdMojo extends AbstractMojo {
               .setCommitIdGenerationMode(commitIdGenerationModeEnum)
               .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment)
               .setExcludeProperties(excludeProperties)
-              .setIncludeOnlyProperties(includeOnlyProperties);
+              .setIncludeOnlyProperties(includeOnlyProperties)
+              .setOffline(offline);
 
       nativeGitProvider.loadGitData(evaluateOnCommit, properties);
     } catch (IOException e) {
@@ -582,7 +591,8 @@ public class GitCommitIdMojo extends AbstractMojo {
         .setCommitIdGenerationMode(commitIdGenerationModeEnum)
         .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment)
         .setExcludeProperties(excludeProperties)
-        .setIncludeOnlyProperties(includeOnlyProperties);
+        .setIncludeOnlyProperties(includeOnlyProperties)
+        .setOffline(offline);
 
     jGitProvider.loadGitData(evaluateOnCommit, properties);
   }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -60,6 +60,8 @@ public abstract class GitDataProvider implements GitProvider {
 
   protected List<String> includeOnlyProperties;
 
+  protected boolean offline;
+
   public GitDataProvider(@Nonnull LoggerBridge log) {
     this.log = log;
   }
@@ -106,6 +108,11 @@ public abstract class GitDataProvider implements GitProvider {
 
   public GitDataProvider setIncludeOnlyProperties(List<String> includeOnlyProperties) {
     this.includeOnlyProperties = includeOnlyProperties;
+    return this;
+  }
+
+  public GitDataProvider setOffline(boolean offline) {
+    this.offline = offline;
     return this;
   }
 

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -335,7 +335,9 @@ public class JGitProvider extends GitDataProvider {
   @Override
   public AheadBehind getAheadBehind() throws GitCommitIdExecutionException {
     try {
-      fetch();
+      if (!offline) {
+        fetch();
+      }
       Optional<BranchTrackingStatus> branchTrackingStatus = Optional.ofNullable(BranchTrackingStatus.of(git, getBranchName()));
       return branchTrackingStatus.map(bts -> AheadBehind.of(bts.getAheadCount(), bts.getBehindCount()))
                                  .orElse(AheadBehind.NO_REMOTE);

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -552,7 +552,9 @@ public class NativeGitProvider extends GitDataProvider {
       if (!remoteBranch.isPresent()) {
         return AheadBehind.NO_REMOTE;
       }
-      fetch(remoteBranch.get());
+      if (!offline) {
+        fetch(remoteBranch.get());
+      }
       String localBranchName = getBranchName();
       String ahead = runQuietGitCommand(canonical, nativeGitTimeoutInMs, "rev-list --right-only --count " + remoteBranch.get() + "..." + localBranchName);
       String behind = runQuietGitCommand(canonical, nativeGitTimeoutInMs, "rev-list --left-only --count " + remoteBranch.get() + "..." + localBranchName);

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -20,6 +20,7 @@ package pl.project13.maven.git;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.eclipse.jgit.api.Git;
 import org.junit.After;
 import org.junit.Before;
@@ -116,6 +117,7 @@ public abstract class GitIntegrationTest {
     mojo.evaluateOnCommit = evaluateOnCommit;
     mojo.nativeGitTimeoutInMs = (30 * 1000);
     mojo.session = mockSession();
+    mojo.settings = mockSettings();
   }
 
   public void setProjectToExecuteMojoIn(@Nonnull MavenProject project) {
@@ -129,6 +131,12 @@ public abstract class GitIntegrationTest {
     when(session.getUserProperties()).thenReturn(new Properties());
     when(session.getSystemProperties()).thenReturn(new Properties());
     return session;
+  }
+
+  private static Settings mockSettings() {
+    Settings settings = mock(Settings.class);
+    when(settings.isOffline()).thenReturn(false);
+    return settings;
   }
 
   private static List<MavenProject> getReactorProjects(@Nonnull MavenProject project) {


### PR DESCRIPTION
Version 3.0.0 started to look at "ahead" and "behind" branches. To do
so, it executes a Fetch command to the repo. This is unfortunate
because it introduces quite a bit of a delay when building, especially
when the machine is offline (e.g. on a plane). Also, it sets off
various alerts because the previous version did not do any remote
access.

This PR introduces an "offline" mode (disabled by default) that allows
turning off all commands that are trying to reach out to
remotes. Currently, that is only the fetch command which is executed
when trying to determine "ahead" and "behind". Any future operation
that is accessing remote repos should also check this flag.

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
