### PR TITLE
Remove the httpclient dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,13 +110,6 @@
       <version>27.1-jre</version>
     </dependency>
 
-    <!-- HttpClient -->
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
-    </dependency>
-
     <!-- JGit -->
     <dependency>
       <groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -18,7 +18,6 @@
 package pl.project13.maven.git;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import org.apache.http.client.utils.URIBuilder;
 import pl.project13.maven.git.build.BuildServerDataProvider;
 import pl.project13.maven.git.build.UnknownBuildServerData;
 import pl.project13.maven.git.log.LoggerBridge;
@@ -53,7 +52,7 @@ public abstract class GitDataProvider implements GitProvider {
   protected CommitIdGenerationMode commitIdGenerationMode;
 
   protected String evaluateOnCommit;
-  
+
   protected boolean useBranchNameFromBuildEnvironment;
 
   protected List<String> excludeProperties;
@@ -95,7 +94,7 @@ public abstract class GitDataProvider implements GitProvider {
     this.dateFormatTimeZone = dateFormatTimeZone;
     return this;
   }
-  
+
   public GitDataProvider setUseBranchNameFromBuildEnvironment(boolean useBranchNameFromBuildEnvironment) {
     this.useBranchNameFromBuildEnvironment = useBranchNameFromBuildEnvironment;
     return this;
@@ -309,13 +308,18 @@ public abstract class GitDataProvider implements GitProvider {
       if (null == userInfoString) {
         return gitRemoteString;
       }
-      URIBuilder b = new URIBuilder(gitRemoteString);
+
       String[] userInfo = userInfoString.split(":");
       // Build a new URL from the original URL, but nulling out the password
       // component of the userinfo. We keep the username so that ssh uris such
       // ssh://git@github.com will retain 'git@'.
-      b.setUserInfo(userInfo[0]);
-      return b.build().toString();
+      return new URI(original.getScheme(),
+              userInfo[0],
+              original.getHost(),
+              original.getPort(),
+              original.getPath(),
+              original.getQuery(),
+              original.getFragment()).toString();
 
     } catch (URISyntaxException e) {
       log.error("Something went wrong to strip the credentials from git's remote url (please report this)!", e);

--- a/src/test/java/pl/project13/maven/git/UriUserInfoRemoverTest.java
+++ b/src/test/java/pl/project13/maven/git/UriUserInfoRemoverTest.java
@@ -56,7 +56,7 @@ public class UriUserInfoRemoverTest {
 
   @Test
   @Parameters(method = "parameters")
-  public void testStripCrecentialsFromOriginUrl(String input, String expected) throws GitCommitIdExecutionException {
+  public void testStripCredentialsFromOriginUrl(String input, String expected) throws GitCommitIdExecutionException {
     GitDataProvider gitDataProvider = mock(GitDataProvider.class);
     when(gitDataProvider.stripCredentialsFromOriginUrl(ArgumentMatchers.any())).thenCallRealMethod();
     String result = gitDataProvider.stripCredentialsFromOriginUrl(input);


### PR DESCRIPTION
This replaces the usage of `org.apache.http.client.utils.URIBuilder` with standard JDK API to get rid of the dependency
```
<dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpclient</artifactId>
      <version>4.5.8</version>
</dependency>
```
### Context (Why)
This plugin has a dependency to apache `httpclient`. Apache `httpclient` has other transitive dependencies, e.g. `commons-logging`. Especially `commons-logging` can cause class loader issues when the user's project classpath contains already a dependency to `commons-logging`.

In my case i ran into:
```
118113 [ERROR] -----------------------------------------------------: org.apache.commons.logging.LogConfigurationException: org.apache.commons.logging.LogConfigurationException: Invalid class loader hierarchy.  You have more than one version of 'org.apache.commons.logging.Log' visible, which is not allowed. (Caused by org.apache.commons.logging.LogConfigurationException: Invalid class loader hierarchy.  You have more than one version of 'org.apache.commons.logging.Log' visible, which is not allowed.) (Caused by org.apache.commons.logging.LogConfigurationException: org.apache.commons.logging.LogConfigurationException: Invalid class loader hierarchy.  You have more than one version of 'org.apache.commons.logging.Log' visible, which is not allowed. (Caused by org.apache.commons.logging.LogConfigurationException: Invalid class loader hierarchy.  You have more than one version of 'org.apache.commons.logging.Log' visible, which is not allowed.))
118114 [ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal pl.project13.maven:git-commit-id-plugin:3.0.0:revision (default) on project dbsearch-connector-ecm: Execution default of goal pl.project13.maven:git-commit-id-plugin:3.0.0:revision failed: An API incompatibility was encountered while executing pl.project13.maven:git-commit-id-plugin:3.0.0:revision: java.lang.ExceptionInInitializerError: null
```

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes (_were already in place_)
- [X] Update the Readme or any other documentation (including relevant Javadoc) (_no occurrences found_)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
