### PR TITLE
Add filtering capabilities for build server data.

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -504,7 +504,9 @@ public class GitCommitIdMojo extends AbstractMojo {
         .setDateFormat(dateFormat)
         .setDateFormatTimeZone(dateFormatTimeZone)
         .setProject(project)
-        .setPrefixDot(prefixDot);
+        .setPrefixDot(prefixDot)
+        .setExcludeProperties(excludeProperties)
+        .setIncludeOnlyProperties(includeOnlyProperties);
 
     buildServerDataProvider.loadBuildData(properties);
   }


### PR DESCRIPTION
### Context
The changes introduced in #185 do not cover the issue reported in #354 where a call to `getHostName()` may take a long time when getting the property `git.build.host`. Likewise, in certain (rare) cases, `TimeZone.getTimeZone()` may also have an impact upon performance when retrieving `git.build.time`. 

Depending on the number of projects, this may have a large effect on compile times as there may be numerous calls to the affected functions. A user should be able to filter these properties from being fetched so that build times can improve if this becomes an issue. This also further aligns with the changes in #185 to be more consistent with not fetching unused properties.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`