### PR TITLE
Fix property caching when using injectAllReactorProjects.

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -532,9 +532,7 @@ public class GitCommitIdMojo extends AbstractMojo {
 
   private void appendPropertiesToReactorProjects() {
     for (MavenProject mavenProject : reactorProjects) {
-
-      // TODO check message
-      log.info("{}] project {}", mavenProject.getName(), mavenProject.getName());
+      log.info("Adding properties to project: {}", mavenProject.getName());
 
       publishPropertiesInto(mavenProject.getProperties());
       mavenProject.setContextValue(CONTEXT_KEY, properties);

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -248,7 +248,7 @@ public abstract class GitDataProvider implements GitProvider {
   protected void maybePut(@Nonnull Properties properties, String key, SupplierEx<String> value)
           throws GitCommitIdExecutionException {
     String keyWithPrefix = prefixDot + key;
-    if (properties.contains(keyWithPrefix)) {
+    if (properties.containsKey(keyWithPrefix)) {
       String propertyValue = properties.getProperty(keyWithPrefix);
       log.info("Using cached {} with value {}", keyWithPrefix, propertyValue);
     } else if (PropertiesFilterer.isIncluded(keyWithPrefix, includeOnlyProperties, excludeProperties)) {

--- a/src/main/java/pl/project13/maven/git/build/BuildServerDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/build/BuildServerDataProvider.java
@@ -166,7 +166,7 @@ public abstract class BuildServerDataProvider {
 
   protected void maybePut(@Nonnull Properties properties, @Nonnull String key, Supplier<String> supplier) {
     String keyWithPrefix = prefixDot + key;
-    if (properties.contains(keyWithPrefix)) {
+    if (properties.containsKey(keyWithPrefix)) {
       String propertyValue = properties.getProperty(keyWithPrefix);
       log.info("Using cached {} with value {}", keyWithPrefix, propertyValue);
     } else if (PropertiesFilterer.isIncluded(keyWithPrefix, includeOnlyProperties, excludeProperties)) {


### PR DESCRIPTION
### Context
When checking for whether a key is within the `Properties` object, using `.contains` is equivalent of `.containsValue`, while the correct invocation is `.containsKey`. This also fixes the logging when saving the `Properties` object to the context.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`