### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.2</version>
+      <version>2.10.3</version>
     </dependency>
 
     <!-- Guava -->

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
     <jgit.version>5.2.2.201904231744-r</jgit.version>
-    <junit.version>5.3.1</junit.version>
+    <junit.version>5.5.1</junit.version>
     <mockito.version>2.27.0</mockito.version>
 
     <fest-assert.version>1.4</fest-assert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>27.1-jre</version>
+      <version>28.0-jre</version>
     </dependency>
 
     <!-- JGit -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-    <jgit.version>5.2.0.201812061821-r</jgit.version>
+    <jgit.version>5.2.2.201904231744-r</jgit.version>
     <junit.version>5.3.1</junit.version>
     <mockito.version>2.27.0</mockito.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.3</version>
     </dependency>
 
     <!-- Joda Time -->

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
     <jgit.version>5.2.2.201904231744-r</jgit.version>
     <junit.version>5.5.1</junit.version>
-    <mockito.version>2.27.0</mockito.version>
+    <mockito.version>3.0.0</mockito.version>
 
     <fest-assert.version>1.4</fest-assert.version>
   </properties>


### PR DESCRIPTION
### Context
Includes:
* update for com.fasterxml.jackson.core: 2.9.9 -> 2.9.9.3 
  * https://nvd.nist.gov/vuln/detail/CVE-2019-14379: SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used, leading to remote code execution.
  * https://nvd.nist.gov/vuln/detail/CVE-2019-14439: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
