### PR TITLE
Make injectAllReactorProjects less verbose.

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -532,11 +532,12 @@ public class GitCommitIdMojo extends AbstractMojo {
 
   private void appendPropertiesToReactorProjects() {
     for (MavenProject mavenProject : reactorProjects) {
-      log.info("Adding properties to project: {}", mavenProject.getName());
+      log.debug("Adding properties to project: {}", mavenProject.getName());
 
       publishPropertiesInto(mavenProject.getProperties());
       mavenProject.setContextValue(CONTEXT_KEY, properties);
     }
+    log.info("Added properties to {} projects", reactorProjects.size());
   }
 
   /**


### PR DESCRIPTION
### Context
injectAllReactorProjects currently prints out each and every project that it injects the properties into. This change moves that to debug level logging only and instead only reports the number of projects that had this property injected into.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`