### PR TITLE
Allow to override useNativeGit from command line

### DIFF
--- a/docs/using-the-plugin.md
+++ b/docs/using-the-plugin.md
@@ -372,6 +372,8 @@ It's really simple to setup this plugin; below is a sample pom that you may base
 
                         Although this should usually give your build some performance boost, it may randomly break if you upgrade your git version and it decides to print information in a different format suddenly.
                         As rule of thumb, keep using the default `jgit` implementation (keep this `false`) until you notice performance problems within your build (usually when you have *hundreds* of maven modules).
+
+                        With version *3.0.2*  you can also control it using the commandline option `-Dmaven.gitcommitid.nativegit=true`
                     -->
                     <useNativeGit>false</useNativeGit>
 

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -198,9 +198,14 @@ public class GitCommitIdMojo extends AbstractMojo {
    * Set this to {@code 'true'} to use native Git executable to fetch information about the repository.
    * It is in most cases faster but requires a git executable to be installed in system.
    * By default the plugin will use jGit implementation as a source of information about the repository.
+   *
+   * NOTE / WARNING:
+   * Do *NOT* set this property inside the configuration of your plugin, so it would be
+   * possible to override it from command line.
+   *
    * @since 2.1.9
    */
-  @Parameter(defaultValue = "false")
+  @Parameter(property = "maven.gitcommitid.nativegit", defaultValue = "false")
   boolean useNativeGit;
 
   /**

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -199,14 +199,24 @@ public class GitCommitIdMojo extends AbstractMojo {
    * It is in most cases faster but requires a git executable to be installed in system.
    * By default the plugin will use jGit implementation as a source of information about the repository.
    *
-   * NOTE / WARNING:
-   * Do *NOT* set this property inside the configuration of your plugin, so it would be
-   * possible to override it from command line.
-   *
    * @since 2.1.9
    */
-  @Parameter(property = "maven.gitcommitid.nativegit", defaultValue = "false")
+  @Parameter(defaultValue = "false")
   boolean useNativeGit;
+
+  /**
+   * Option to be used in command-line to override the value of {@code 'useNativeGit'} specified in
+   * the pom.xml, or its default value if it's not set explicitly.
+   *
+   *  NOTE / WARNING:
+   *  Do *NOT* set this property inside the configuration of your plugin.
+   *  Please read https://github.com/git-commit-id/maven-git-commit-id-plugin/issues/315
+   *  to find out why.
+   *
+   * @since 3.0.2
+   */
+  @Parameter(property = "maven.gitcommitid.nativegit", defaultValue = "false")
+  boolean useNativeGitViaCommandLine;
 
   /**
    * Set this to {@code 'true'} to skip plugin execution.
@@ -562,8 +572,15 @@ public class GitCommitIdMojo extends AbstractMojo {
     }
   }
 
+  private boolean isUseNativeGit() {
+    if (System.getProperty("maven.gitcommitid.nativegit") != null) {
+      return useNativeGitViaCommandLine;
+    }
+    return useNativeGit;
+  }
+
   private void loadGitData(@Nonnull Properties properties) throws GitCommitIdExecutionException {
-    if (useNativeGit) {
+    if (isUseNativeGit()) {
       loadGitDataWithNativeGit(properties);
     } else {
       loadGitDataWithJGit(properties);


### PR DESCRIPTION
Right now, because JGit doesn't support Git worktrees, I need to override `useNativeGit`
in the `pom.xml` of different projects, and it's easy to make a mistake and commit the
changes.

The proposed PR should allow to override this property from command-line via
`maven.gitcommitid.nativegit`, without modification of the `pom.xml`.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
