### PR TITLE
wrong prefix of comment line

### DIFF
--- a/docs/using-the-plugin.md
+++ b/docs/using-the-plugin.md
@@ -235,7 +235,7 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <skip>false</skip>
 
                     <!-- @since 3.0.1 -->
-                    <--
+                    <!--
                         Default (optional):
                         false
 


### PR DESCRIPTION
This seems to be a typo: the comment line should start with <!--
The user would have to manually correct the typo.

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
