### PR TITLE
upgrade jackson-databind to fix CVE-2019-14540 and CVE-2019-16335

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.3</version>
+      <version>2.9.10</version>
     </dependency>
 
     <!-- Joda Time -->


### PR DESCRIPTION
upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.9.3 to 2.9.10 in order to fix [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) and [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335)