### PR TITLE
Issue #438 Populate "git.branch" and "git.build.number" for Azure DevOps

### DIFF
--- a/docs/using-the-plugin.md
+++ b/docs/using-the-plugin.md
@@ -712,6 +712,6 @@ Refer to the table below to see which values are supported by which CIs.
  
  | variable                  | description                             | supported CIs                                             |    
  | ------------------------- | ----------------------------------------|:---------------------------------------------------------:|   
- |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5)|        
+ |`git.build.number`         | holds a project specific build number   | Bamboo, Hudson, Jenkins, TeamCity, Travis, Gitlab CI (Gitlab >8.10 & Gitlab CI >0.5), Azure DevOps|        
  |`git.build.number.unique`  | holds a system wide unique build number | TeamCity, Travis, Gitlab CI (Gitlab >11.0)                          |
 

--- a/src/main/java/pl/project13/maven/git/build/AzureDevOpsBuildServerData.java
+++ b/src/main/java/pl/project13/maven/git/build/AzureDevOpsBuildServerData.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.maven.git.build;
+
+import pl.project13.maven.git.GitCommitPropertyConstant;
+import pl.project13.maven.git.log.LoggerBridge;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Properties;
+
+public class AzureDevOpsBuildServerData extends BuildServerDataProvider {
+
+  AzureDevOpsBuildServerData(@Nonnull LoggerBridge log, @Nonnull Map<String, String> env) {
+    super(log, env);
+  }
+
+  /**
+   * @see <a href="https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables">Azure DevOps - Build variables</a>
+   */
+  public static boolean isActiveServer(@Nonnull Map<String, String> env) {
+    return env.containsKey("AZURE_HTTP_USER_AGENT");
+  }
+
+  @Override
+  void loadBuildNumber(@Nonnull Properties properties) {
+    String buildNumber = env.get("BUILD_BUILDNUMBER");
+
+    put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber == null ? "" : buildNumber);
+  }
+
+  @Override
+  public String getBuildBranch() {
+    String environmentBasedBuildSourceBranchName = env.get("BUILD_SOURCEBRANCHNAME");
+    log.info("Using environment variable based branch name. BUILD_SOURCEBRANCHNAME = {}", environmentBasedBuildSourceBranchName);
+    return environmentBasedBuildSourceBranchName;
+  }
+}

--- a/src/main/java/pl/project13/maven/git/build/BuildServerDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/build/BuildServerDataProvider.java
@@ -103,6 +103,9 @@ public abstract class BuildServerDataProvider {
     if (TravisBuildServerData.isActiveServer(env)) {
       return new TravisBuildServerData(log, env);
     }
+    if (AzureDevOpsBuildServerData.isActiveServer(env)) {
+      return new AzureDevOpsBuildServerData(log, env);
+    }
     return new UnknownBuildServerData(log, env);
   }
 


### PR DESCRIPTION
### Context
Populate "git.branch" and "git.build.number" for Azure DevOps

```
2019-10-01T09:20:52.8249155Z BUILD_BUILDNUMBER=20191001.1
2019-10-01T09:20:52.8249357Z BUILD_SOURCEBRANCHNAME=74902_build_info-and-pipelines_v3
...
2019-10-01T09:21:01.5141375Z [INFO] Collected git.build.number with value 20191001.1
...
2019-10-01T09:21:00.9696385Z [INFO] Using environment variable based branch name. BUILD_SOURCEBRANCHNAME = 74902_build_info-and-pipelines_v3
2019-10-01T09:21:00.9747110Z [INFO] Collected git.branch with value 74902_build_info-and-pipelines_v
```

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
