### PR TITLE
#387: make runOnlyOnce run on the first project (and make it work when maven's --projects param are specified)

### DIFF
--- a/maven/docs/using-the-plugin.md
+++ b/maven/docs/using-the-plugin.md
@@ -254,16 +254,23 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         Explanation:
                         Use with caution!
 
-                        In a multi-module build, only run once. This means that the plugins effects will only execute once, for the parent project.
+                        In a multi-module build, only run once. This means that the plugins effects will only execute
+                        once for the first project in the execution graph. If `skipPoms` is set to true (default)
+                        the plugin will run for the first non pom project in the execution graph (as listed in the reactor build order).
                         This probably won't "do the right thing" if your project has more than one git repository.
 
                         Important: If you're using `generateGitPropertiesFile`, setting `runOnlyOnce` will make the plugin
-                        only generate the file in the directory where you started your build (!).
+                        only generate the file in the project build directory which is the first one based on the execution graph (!).
 
                         Important: Please note that the git-commit-id-plugin also has an option to skip pom project (`<packaging>pom</packaging>`).
                         If you plan to use the `runOnlyOnce` option alongside with an aggregator pom you may want to set `<skipPoms>false</skipPoms>`.
 
-                        The `git.*` maven properties are available in all modules.
+                        For multi-module build you might also want to set `injectAllReactorProjects` to make
+                        the `git.*` maven properties available in all modules.
+
+                        Note:
+                        prior to version 4.0.0 the plugin was simply using the execute once applied for the parent project
+                        (which might have skipped execution if the parent project was a pom project).
                     -->
                     <runOnlyOnce>false</runOnlyOnce>
 

--- a/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/maven/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -419,8 +419,16 @@ public class GitCommitIdMojo extends AbstractMojo {
       }
 
       if (runOnlyOnce) {
-        if (!session.getExecutionRootDirectory().equals(session.getCurrentProject().getBasedir().getAbsolutePath())) {
-          log.info("runOnlyOnce is enabled and this project is not the top level project, skipping execution!");
+        List<MavenProject> sortedProjects = session.getProjectDependencyGraph().getSortedProjects();
+        MavenProject firstProject = sortedProjects.isEmpty()
+                ? session.getCurrentProject()
+                : sortedProjects.get(0);
+
+        log.info("Current project: '" + session.getCurrentProject().getName() +
+                "', first project to execute based on dependency graph: '" + firstProject.getName() + "'" );
+
+        if (!session.getCurrentProject().equals(firstProject)) {
+          log.info("runOnlyOnce is enabled and this project is not the first project, skipping execution!");
           return;
         }
       }


### PR DESCRIPTION
### Context
see: https://github.com/git-commit-id/maven-git-commit-id-plugin/issues/387

In most cases this doesn't change much, however for some this might be considered a behavioral change (and thus fits a major version change). In specific when `runOnlyOnce` is specified the plugin will run on the `first project` as specified in the `Reactor Build Order`.

As per debugging project:
```
$ mvn clean package -Pgit-with-parent
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Git Commit Id Plugin Maven Mojo Debugging
[INFO] submodule-one
[INFO] submodule-two
```

or with `--projects`
```
$ mvn clean package -Pgit-with-parent --projects submodule-one,submodule-two
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] submodule-one
[INFO] submodule-two
```
or vice versa (the `pom.xml` seems to take precedence):
```
$ mvn clean package -Pgit-with-parent --projects submodule-two,submodule-one
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] submodule-one
[INFO] submodule-two
```

Inspired by [sonar-scanner-maven plugin](https://github.com/SonarSource/sonar-scanner-maven/blob/8217cc600256052b6d2320fcb8e50caeb0f261a4/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java#L133)

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
