### PR TITLE
Add support for CircleCI

### DIFF
--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -100,8 +100,8 @@ public abstract class BuildServerDataProvider {
     if (AzureDevOpsBuildServerData.isActiveServer(env)) {
       return new AzureDevOpsBuildServerData(log, env);
     }
-    if (CircleCIBuildServerData.isActiveServer(env)) {
-      return new CircleCIBuildServerData(log, env);
+    if (CircleCiBuildServerData.isActiveServer(env)) {
+      return new CircleCiBuildServerData(log, env);
     }
     return new UnknownBuildServerData(log, env);
   }

--- a/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
+++ b/core/src/main/java/pl/project13/core/cibuild/BuildServerDataProvider.java
@@ -100,6 +100,9 @@ public abstract class BuildServerDataProvider {
     if (AzureDevOpsBuildServerData.isActiveServer(env)) {
       return new AzureDevOpsBuildServerData(log, env);
     }
+    if (CircleCIBuildServerData.isActiveServer(env)) {
+      return new CircleCIBuildServerData(log, env);
+    }
     return new UnknownBuildServerData(log, env);
   }
 

--- a/core/src/main/java/pl/project13/core/cibuild/CircleCIBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/CircleCIBuildServerData.java
@@ -24,38 +24,29 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Properties;
 
-public class GitlabBuildServerData extends BuildServerDataProvider {
+public class CircleCIBuildServerData extends BuildServerDataProvider {
 
-  GitlabBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
+  CircleCIBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
     super(log,env);
   }
 
   /**
-   * @see <a href="https://docs.gitlab.com/ce/ci/variables/predefined_variables.html">GitlabCIVariables</a>
+   * @see <a href="https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables">CircleCIBuiltInVariables</a>
    */
   public static boolean isActiveServer(Map<String, String> env) {
-    // CI is not unique to Gitlab CI (e.g. CircleCI). Use GITLAB_CI instead.
-    return env.containsKey("GITLAB_CI");
+    return env.containsKey("CIRCLECI");
   }
 
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
-    // GITLAB CI
-    // CI_PIPELINE_ID will be present if in a Gitlab CI environment (Gitlab >8.10 & Gitlab CI >0.5)  and contains a server wide unique ID for a pipeline run
-    String uniqueBuildNumber = env.get("CI_PIPELINE_ID");
-    // CI_PIPELINE_IID will be present if in a Gitlab CI environment (Gitlab >11.0) and contains the project specific build number
-    String buildNumber = env.get("CI_PIPELINE_IID");
-
+    String buildNumber = env.get("CIRCLE_BUILD_NUM");
     put(properties, GitCommitPropertyConstant.BUILD_NUMBER, buildNumber == null ? "" : buildNumber);
-    put(properties,
-        GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE,
-        uniqueBuildNumber == null ? "" : uniqueBuildNumber);
   }
 
   @Override
   public String getBuildBranch() {
-    String environmentBasedBranch = env.get("CI_COMMIT_REF_NAME");
-    log.info("Using environment variable based branch name. CI_COMMIT_REF_NAME = {}", environmentBasedBranch);
+    String environmentBasedBranch = env.get("CIRCLE_BRANCH");
+    log.info("Using environment variable based branch name. CIRCLE_BRANCH = {}", environmentBasedBranch);
     return environmentBasedBranch;
   }
 }

--- a/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
+++ b/core/src/main/java/pl/project13/core/cibuild/CircleCiBuildServerData.java
@@ -24,9 +24,9 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Properties;
 
-public class CircleCIBuildServerData extends BuildServerDataProvider {
+public class CircleCiBuildServerData extends BuildServerDataProvider {
 
-  CircleCIBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
+  CircleCiBuildServerData(LoggerBridge log, @Nonnull Map<String, String> env) {
     super(log,env);
   }
 


### PR DESCRIPTION
### Context
This adds support for CircleCI for this plugin. It's useful for getting branch name and revision number when running on CircleCI.

### Contributor Checklist
- [:x:] Added relevant integration or unit tests to verify the changes
- [:heavy_check_mark:] Update the Readme or any other documentation (including relevant Javadoc)
- [:heavy_check_mark:] Ensured that tests pass locally: `mvn clean package`
- [:heavy_check_mark:] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`

### Notes
I couldn't find any tests that tested that sort of thing, hence why I didn't add any.
